### PR TITLE
fix missing detection of reset during write of zero-bits

### DIFF
--- a/OneWireSlave.cpp
+++ b/OneWireSlave.cpp
@@ -209,6 +209,12 @@ void OneWireSlave::beginResetDetection_()
 	resetStart_ = micros() - 50;
 }
 
+void OneWireSlave::beginResetDetectionSendZero_()
+{
+	setTimerEvent_(ResetMinDuration - SendBitDuration - 50, &OneWireSlave::resetCheck_);
+	resetStart_ = micros() - SendBitDuration - 50;
+}
+
 void OneWireSlave::cancelResetDetection_()
 {
 	disableTimer_();
@@ -298,6 +304,7 @@ void OneWireSlave::endSendBitZero_()
 	onEnterInterrupt_();
 
 	releaseBus_();
+	beginResetDetectionSendZero_();
 	bitSentCallback_(false);
 
 	onLeaveInterrupt_();

--- a/OneWireSlave.h
+++ b/OneWireSlave.h
@@ -53,6 +53,7 @@ private:
 	static void beginSendBit_(bool bit, void(*completeCallback)(bool error));
 
 	static void beginResetDetection_();
+	static void beginResetDetectionSendZero_();
 	static void cancelResetDetection_();
 
 	static void beginWaitReset_();


### PR DESCRIPTION
Writing a clone of DS2890 I noticed that reset is not detected after OWSlave.write(0,true); has been called.
